### PR TITLE
Added cmake support. Changed include paths.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Makefile*
 # QtCtreator CMake
 CMakeLists.txt.user*
 
+# Visual studio files
+CMakeSettings.json
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.10)
+project(OpenCK)
+
+option(BUILD_DOC "Build documentation" ON)
+
+find_package(Doxygen)
+
+if(BUILD_DOC AND DOXYGEN_FOUND)
+
+	doxygen_add_docs(doxygen_docs
+					 doc
+					 src
+					 COMMENT "Generate documentation"
+					 )
+
+else()
+	message("Doxygen required to build documentation.")
+endif()
+
+# Option macro
+macro(set_option var default type docstring)
+	if(NOT DEFINED %{var})
+		set(${var} ${default})
+	endif()
+	set(${var} ${${var}} CACHE ${type} ${docstring} FORCE)
+endmacro()
+
+# Option for manually finding QT library path.
+set_option(QT_DIR "" PATH "Path to QT library.")
+if(QT_DIR)
+	set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT_DIR})
+endif()
+
+# cmake modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Find dependencies.
+find_package(Qt5Core)
+find_package(Qt5Widgets)
+find_package(Qt5Gui)
+find_package(Qt5Svg)
+
+# Grab version from src/VERSION
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/VERSION")
+	file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/src/VERSION" OPENCK_VERSION)
+endif()
+
+if(OPENCK_VERSION)
+	add_definitions(-DOPENCK_VERSION="${OPENCK_VERSION}")
+else()
+	add_definitions(-DOPENCK_VERSION="0")
+endif()
+
+# Grab GIT revision and place in OPENCK_REVISION
+include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+
+if(GIT_SHA1)
+add_definitions(-DOPENCK_REVISION="${GIT_SHA1}")
+endif()
+
+
+# Source files
+include_directories(src)
+add_subdirectory(src)

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -1,0 +1,168 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+			# We have reached the root directory, we are not in git
+			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			return()
+		endif()
+		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	endwhile()
+	# check if this is a submodule
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		file(READ ${GIT_DIR} submodule)
+		string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+		get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+		get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+	endif()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${GIT_DIR}/HEAD")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+		"${GIT_DATA}/grabRef.cmake"
+		@ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
+	set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		describe
+		${hash}
+		${ARGN}
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		diff-index --quiet HEAD --
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(res EQUAL 0)
+		set(${_var} "CLEAN" PARENT_SCOPE)
+	else()
+		set(${_var} "DIRTY" PARENT_SCOPE)
+	endif()
+endfunction()

--- a/cmake/GetGitRevisionDescription.cmake.in
+++ b/cmake/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,41 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,110 @@
+set(DATA_SRC
+	data/form.cpp
+	data/form.h
+
+	data/formcomponents.h
+	data/functionindexes.h
+
+	# Records
+	data/records/classform.cpp
+	data/records/classform.h
+
+	data/records/factionform.cpp
+	data/records/factionform.h
+
+	data/records/gamesettingform.cpp
+	data/records/gamesettingform.h
+
+	data/records/globalvariableform.cpp
+	data/records/globalvariableform.h
+
+	data/records/rgbform.cpp
+	data/records/rgbform.h
+
+	data/records/tes4form.cpp
+	data/records/tes4form.h
+
+	data/records/texturesetform.cpp
+	data/records/texturesetform.h
+
+	# Subrecords
+	data/subrecords/conditionitemcountfield.h
+
+	data/subrecords/interfactionrelationsfield.h
+
+	data/subrecords/objectboundsfield.h
+)
+
+set(IO_SRC
+	io/formfactory.cpp
+	io/formfactory.h
+
+	io/parser.cpp
+	io/parser.h
+
+	io/reader.h
+)
+
+set(MODELS_SRC
+	
+	models/filemodel.cpp
+	models/filemodel.h
+
+	models/formmodel.cpp
+	models/formmodel.h
+)
+
+SET(UI_SRC
+
+	ui/mainwindow.cpp
+	ui/mainwindow.h
+	ui/mainwindow.ui
+
+	ui/datawindow.cpp
+	ui/datawindow.h
+	ui/datawindow.ui
+	
+	ui/renderwindow.cpp
+	ui/renderwindow.h
+	ui/renderwindow.ui
+)
+
+# Pulls in all sources.
+SET(SRC
+	main.cpp
+	
+	version.cpp
+	version.h
+
+	${DATA_SRC}
+	${IO_SRC}
+	${MODELS_SRC}
+	${UI_SRC}
+)
+
+# QT .qrc resource files.
+SET(QTRES
+	../res/resources.qrc
+)
+
+# Set QT to automatically detect and run moc on our sources.
+set (CMAKE_AUTOMOC ON)
+set (CMAKE_AUTOUIC ON)
+set (CMAKE_AUTORCC ON)
+set (CMAKE_INCLUDE_CURRENT_DIR ON)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# Build executable target and link any libraries.
+add_executable(${PROJECT_NAME} ${SRC} ${UI_SRC} ${QTRES})
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Svg)
+
+# Deploy required QT dlls for windows builds to the current binary directory.
+if (WIN32)
+    get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
+    get_filename_component(QT5_WINDEPLOYQT_EXECUTABLE ${QT5_QMAKE_EXECUTABLE} PATH)
+    set(QT5_WINDEPLOYQT_EXECUTABLE "${QT5_WINDEPLOYQT_EXECUTABLE}/windeployqt.exe")
+
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+					   COMMAND ${QT5_WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_SOURCE_DIR} $<TARGET_FILE_DIR:${PROJECT_NAME}>
+	)
+endif(WIN32)

--- a/src/data/form.cpp
+++ b/src/data/form.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 10-Jul-2017
 */
 
-#include "form.h"
-#include "reader.h"
+#include <data/form.h>
+#include <io/reader.h>
 
 //!@file form.cpp Source for parsing Forms from .esm and .esp files.
 

--- a/src/data/form.h
+++ b/src/data/form.h
@@ -42,7 +42,7 @@ public: \
 #include <QtEndian>
 #include <QObject>
 
-#include "reader.h"
+#include <io/reader.h>
 
 namespace esx
 {

--- a/src/data/records/classform.cpp
+++ b/src/data/records/classform.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 17-Oct-2017
 */
 
-#include "classform.h"
-#include "parser.h"
+#include <data/records/classform.h>
+#include <io/parser.h>
 
 namespace esx
 {

--- a/src/data/records/classform.h
+++ b/src/data/records/classform.h
@@ -36,7 +36,7 @@ public: \
     const type& get##name##() const { return name; } \
     void set##name##(const type& newval) { name = newval; }
 
-#include "form.h"
+#include <data/form.h>
 
 namespace esx
 {

--- a/src/data/records/factionform.cpp
+++ b/src/data/records/factionform.cpp
@@ -1,4 +1,4 @@
-#include "records/factionform.h"
+#include <data/records/factionform.h>
 
 namespace esx
 {

--- a/src/data/records/factionform.h
+++ b/src/data/records/factionform.h
@@ -36,9 +36,9 @@ public: \
 
 #include <vector>
 
-#include "form.h"
-#include "interfactionrelationsfield.h"
-#include "conditionitemcountfield.h"
+#include <data/form.h>
+#include <data/subrecords/interfactionrelationsfield.h>
+#include <data/subrecords/conditionitemcountfield.h>
 
 namespace esx
     {

--- a/src/data/records/gamesettingform.cpp
+++ b/src/data/records/gamesettingform.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 28-Jul-2017
 */
 
-#include "gamesettingform.h"
-#include "parser.h"
+#include <data/records/gamesettingform.h>
+#include <io/parser.h>
 
 namespace esx
 {

--- a/src/data/records/gamesettingform.h
+++ b/src/data/records/gamesettingform.h
@@ -34,7 +34,7 @@ public: \
     const type& get##name##() const { return name; } \
     void set##name##(const type& newval) { name = newval; }
 
-#include "form.h"
+#include <data/form.h>
 
 namespace esx
 {

--- a/src/data/records/globalvariableform.cpp
+++ b/src/data/records/globalvariableform.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 16-Oct-2017
 */
 
-#include "globalvariableform.h"
-#include "parser.h"
+#include <data/records/globalvariableform.h>
+#include <io/parser.h>
 
 namespace esx
 {

--- a/src/data/records/globalvariableform.h
+++ b/src/data/records/globalvariableform.h
@@ -36,7 +36,7 @@ public: \
     const type& get##name##() const { return name; } \
     void set##name##(const type& newval) { name = newval; }
 
-#include "form.h"
+#include <data/form.h>
 
 namespace esx
 {

--- a/src/data/records/rgbform.cpp
+++ b/src/data/records/rgbform.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 14-Aug-2017
 */
 
-#include "rgbform.h"
-#include "parser.h"
+#include <data/records/rgbform.h>
+#include <io/parser.h>
 
 namespace esx
 {

--- a/src/data/records/rgbform.h
+++ b/src/data/records/rgbform.h
@@ -36,7 +36,7 @@ public: \
     const type& get##name##() const { return name; } \
     void set##name##(const type& newval) { name = newval; }
 
-#include "form.h"
+#include <data/form.h>
 
 namespace esx
 {

--- a/src/data/records/tes4form.cpp
+++ b/src/data/records/tes4form.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 10-Jul-2017
 */
 
-#include "records/tes4form.h"
-#include "parser.h"
+#include <data/records/tes4form.h>
+#include <io/parser.h>
 
 //!@file tes4form.cpp The header form.
 

--- a/src/data/records/tes4form.h
+++ b/src/data/records/tes4form.h
@@ -36,7 +36,7 @@ public: \
     const type& get##name##() const { return name; } \
     void set##name##(const type& newval) { name = newval; }
 
-#include "form.h"
+#include <data/form.h>
 
 namespace esx
 {

--- a/src/data/records/texturesetform.cpp
+++ b/src/data/records/texturesetform.cpp
@@ -1,5 +1,5 @@
-#include "texturesetform.h"
-#include "parser.h"
+#include <data/records/texturesetform.h>
+#include <io/parser.h>
 
 namespace esx
 {

--- a/src/data/records/texturesetform.h
+++ b/src/data/records/texturesetform.h
@@ -36,8 +36,8 @@ public: \
     const type& get##name##() const { return name; } \
     void set##name##(const type& newval) { name = newval; }
 
-#include "form.h"
-#include "subrecords/objectboundsfield.h"
+#include <data/form.h>
+#include <data/subrecords/objectboundsfield.h>
 
 namespace esx
 {

--- a/src/io/formfactory.cpp
+++ b/src/io/formfactory.cpp
@@ -24,7 +24,7 @@
 ** Created Date: 06-Oct-2017
 */
 
-#include "formfactory.h"
+#include <io/formfactory.h>
 
 namespace io
 {

--- a/src/io/formfactory.h
+++ b/src/io/formfactory.h
@@ -27,12 +27,12 @@
 #ifndef FORMFACTORY_H
 #define FORMFACTORY_H
 
-#include "records/tes4form.h"
-#include "records/gamesettingform.h"
-#include "records/rgbform.h"
-#include "records/texturesetform.h"
-#include "records/globalvariableform.h"
-#include "records/classform.h"
+#include <data/records/tes4form.h>
+#include <data/records/gamesettingform.h>
+#include <data/records/rgbform.h>
+#include <data/records/texturesetform.h>
+#include <data/records/globalvariableform.h>
+#include <data/records/classform.h>
 
 namespace io
 {

--- a/src/io/parser.cpp
+++ b/src/io/parser.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 08-Jul-2017
 */
 
-#include "parser.h"
-#include "formfactory.h"
+#include <io/parser.h>
+#include <io/formfactory.h>
 
 namespace io
 {

--- a/src/io/parser.h
+++ b/src/io/parser.h
@@ -43,10 +43,10 @@
 #include <string>
 #include <cmath>
 
-#include "reader.h"
-#include "filemodel.h"
-#include "formmodel.h"
-#include "formfactory.h"
+#include <io/reader.h>
+#include <models/filemodel.h>
+#include <models/formmodel.h>
+#include <io/formfactory.h>
 
 namespace io
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@
 ** Created Date: 04-Jul-2017
 */
 
-#include "mainwindow.h"
+#include <ui/mainwindow.h>
 #include <QApplication>
 
 //!@file main.cpp Application entry point.

--- a/src/models/filemodel.cpp
+++ b/src/models/filemodel.cpp
@@ -24,8 +24,8 @@
 ** Created Date: 18-Jul-2017
 */
 
-#include "filemodel.h"
-#include "parser.h"
+#include <models/filemodel.h>
+#include <io/parser.h>
 
 namespace models
 {

--- a/src/models/filemodel.h
+++ b/src/models/filemodel.h
@@ -35,12 +35,12 @@
 #include <QList>
 #include <QObject>
 
-#include "records/tes4form.h"
-#include "records/gamesettingform.h"
-#include "records/rgbform.h"
-#include "records/texturesetform.h"
-#include "records/globalvariableform.h"
-#include "records/classform.h"
+#include <data/records/tes4form.h>
+#include <data/records/gamesettingform.h>
+#include <data/records/rgbform.h>
+#include <data/records/texturesetform.h>
+#include <data/records/globalvariableform.h>
+#include <data/records/classform.h>
 
 namespace models
 {

--- a/src/models/formmodel.cpp
+++ b/src/models/formmodel.cpp
@@ -24,9 +24,9 @@
 ** Created Date: 26-Jul-2017
 */
 
-#include "formmodel.h"
-#include "parser.h"
-#include "formcomponents.h"
+#include <models/formmodel.h>
+#include <io/parser.h>
+#include <data/formcomponents.h>
 
 //!@file filemodel.cpp Source for the File Model and its respective items.
 

--- a/src/models/formmodel.h
+++ b/src/models/formmodel.h
@@ -35,13 +35,13 @@
 #include <QList>
 #include <QObject>
 
-#include "form.h"
-#include "records/tes4form.h"
-#include "records/gamesettingform.h"
-#include "records/rgbform.h"
-#include "records/texturesetform.h"
-#include "records/globalvariableform.h"
-#include "records/classform.h"
+#include <data/form.h>
+#include <data/records/tes4form.h>
+#include <data/records/gamesettingform.h>
+#include <data/records/rgbform.h>
+#include <data/records/texturesetform.h>
+#include <data/records/globalvariableform.h>
+#include <data/records/classform.h>
 
 namespace models
 {

--- a/src/ui/datawindow.cpp
+++ b/src/ui/datawindow.cpp
@@ -25,7 +25,7 @@
 */
 
 
-#include "datawindow.h"
+#include <ui/datawindow.h>
 #include "ui_datawindow.h"
 
 //!@file datawindow.cpp Source for the Data window.

--- a/src/ui/datawindow.h
+++ b/src/ui/datawindow.h
@@ -35,7 +35,7 @@
 #include <QTableView>
 #include <QStandardItemModel>
 #include <QMessageBox>
-#include "parser.h"
+#include <io/parser.h>
 
 namespace Ui
 {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -24,7 +24,7 @@
 ** Created Date: 04-Jul-2017
 */
 
-#include "mainwindow.h"
+#include <ui/mainwindow.h>
 #include "ui_mainwindow.h"
 
 #include <QActionGroup>

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -35,11 +35,11 @@
 #include <QDesktopServices>
 #include <QUrl>
 
-#include "datawindow.h"
-#include "renderwindow.h"
+#include <ui/datawindow.h>
+#include <ui/renderwindow.h>
 
-#include "filemodel.h"
-#include "formmodel.h"
+#include <models/filemodel.h>
+#include <models/formmodel.h>
 
 namespace Ui
 {

--- a/src/ui/renderwindow.cpp
+++ b/src/ui/renderwindow.cpp
@@ -24,7 +24,7 @@
 ** Created Date: 18-Jul-2017
 */
 
-#include "renderwindow.h"
+#include <ui/renderwindow.h>
 #include "ui_renderwindow.h"
 
 //!@file renderwindow.cpp Source for the Render Window.

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -24,7 +24,7 @@
 ** Created Date: 19-Jul-2017
 */
 
-#include "version.h"
+#include <version.h>
 
 #include "QDebug"
 


### PR DESCRIPTION
I have added initial cmake support to the project. May need validating for environments other than Visual Studio and QT creator. There's no generator as far as I can tell for a *.pro project but QT creator natively supports opening a cmake project by opening the CMakeLists.txt file.

In addition I changed the include paths to this format:
#include <data/records/classform.h>
instead of:
#include "classform.h"
but that can be reverted with the addition of the respective folders to include_directories(...) if necessary.

In the case that QT is not found by the system a direct path to it can be defined by exporting QT_PATH. QT creator should have no troubles resolving it by itself.