### PR TITLE
Added data/scriptmanagerdata.h to CMakeLists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ set(DATA_SRC
 
     data/formhashmap.h
 
+	data/scriptmanagerdata.h
+
     # Records
     data/records/classform.cpp
     data/records/classform.h


### PR DESCRIPTION
Looks like this header file was missing from src/CMakeLists.txt, adding it in seems to have fixed the linker error.