### PR TITLE
Adds localization flag to reader and temporary checks.

### DIFF
--- a/src/data/records/classform.cpp
+++ b/src/data/records/classform.cpp
@@ -56,14 +56,27 @@ namespace esx
                     this->setEditorID(r.readZstring());
                     read += this->getEditorID().length();
                     break;
-                case 'FULL':
-                    this->setFullName(r.read<quint32>());
-                    read += 4;
+                case 'FULL': {
+
+                    if (r.isLocalizationEnabled()) { // TODO: Implement proper localization handling.
+                        this->setFullName(QString::number(r.read<quint32>(), 16));
+                        read += 4;
+                    } else {
+                        this->setFullName(r.readZstring());
+                        read += this->getFullName().size();
+                    }
                     break;
-                case 'DESC':
-                    this->setDesc(r.read<quint32>());
-                    read += 4;
+                }
+                case 'DESC': {
+                    if (r.isLocalizationEnabled()) {
+                        this->setDesc(QString::number(r.read<quint32>(), 16));
+                        read += 4;
+                    } else {
+                        this->setDesc(r.readZstring());
+                        read += this->getDesc().size();
+                    }
                     break;
+                }
                 case 'ICON':
                     this->setIcon(r.readZstring());
                     read += this->getIcon().length() + 1;

--- a/src/data/records/classform.h
+++ b/src/data/records/classform.h
@@ -69,8 +69,8 @@ namespace esx
         Q_OBJECT
 
         FORM_MEMBER(QString, EditorID)
-        FORM_MEMBER(quint32, FullName)
-        FORM_MEMBER(quint32, Desc)
+        FORM_MEMBER(QString, FullName)
+        FORM_MEMBER(QString, Desc)
         FORM_MEMBER(QString, Icon)
         FORM_MEMBER(classInf, ClassData)
 

--- a/src/data/records/factionform.cpp
+++ b/src/data/records/factionform.cpp
@@ -83,10 +83,18 @@ namespace esx
                     this->setEditorID(r.readZstring());
                     read += this->getEditorID().length();
                     break;
-                case 'FULL': // Full name
-                    this->setFullName(r.read<quint32>());
-                    read += sizeof(quint32);
+                // Full name
+                case 'FULL': {
+
+                    if (r.isLocalizationEnabled()) { // TODO: Handle localized strings properly.
+                        this->setFullName(QString::number(r.read<quint32>(), 16));
+                        read += sizeof(quint32);
+                    } else {
+                        this->setFullName(r.readZstring());
+                        read += this->getFullName().length();
+                    }
                     break;
+                }
                 // Interfaction relations.
                 case 'XNAM': {
                     InterfactionRelations rel;
@@ -200,15 +208,31 @@ namespace esx
                     break;
                 }
                 // Male Rank Title
-                case 'MNAM':
-                    Ranks.back().maleTitle = r.read<quint32>();
-                    read += sizeof(quint32);
+                case 'MNAM': {
+
+                    if (r.isLocalizationEnabled()) { // TODO: Handle localization properly.
+                        Ranks.back().maleTitle = QString::number(r.read<quint32>(), 16);
+                        read += sizeof(quint32);
+                    } else {
+                        auto& rank = Ranks.back();
+                        rank.maleTitle = r.readZstring();
+                        read += rank.maleTitle.size();
+                    }
                     break;
+                }
                 // Female Rank Title
-                case 'FNAM':
-                    Ranks.back().femaleTitle = r.read<quint32>();
-                    read += sizeof(quint32);
+                case 'FNAM': {
+
+                    if (r.isLocalizationEnabled()) {
+                        Ranks.back().femaleTitle = QString::number(r.read<quint32>(), 16);
+                        read += sizeof(quint32);
+                    } else {
+                        auto& rank = Ranks.back();
+                        rank.femaleTitle = r.readZstring();
+                        read += rank.femaleTitle.size();
+                    }
                     break;
+                }
                  // Vendor List
                 case 'VEND':
                     this->setVendorList(r.read<quint32>());

--- a/src/data/records/factionform.h
+++ b/src/data/records/factionform.h
@@ -64,8 +64,8 @@ namespace esx
     struct Rank
     {
         quint32 rankID{ 0 };
-        quint32 maleTitle{ 0 };
-        quint32 femaleTitle{ 0 };
+        QString maleTitle;
+        QString femaleTitle;
     };
 
     struct VendorInf
@@ -95,7 +95,7 @@ namespace esx
         Q_OBJECT
 
         FORM_MEMBER(QString, EditorID)
-        FORM_MEMBER(quint32, FullName)
+        FORM_MEMBER(QString, FullName)
         FORM_MEMBER(std::vector<InterfactionRelations>, Relations)
         FORM_MEMBER(quint32, Flags)
         FORM_MEMBER(quint32, PrisonMarker)
@@ -115,7 +115,7 @@ namespace esx
 
     public:
         FactionForm()
-            : EditorID(""), FullName(0), Flags(0), PrisonMarker(0), FollowerWaitMarker(0), EvidenceChest(0), BelongingsChest(0),
+            : EditorID(""), FullName(""), Flags(0), PrisonMarker(0), FollowerWaitMarker(0), EvidenceChest(0), BelongingsChest(0),
             CrimeGroup(0), JailOutfit(0), VendorList(0), VendorChest(0) {}
         FactionForm(const Form&);
         ~FactionForm() = default;

--- a/src/data/records/gamesettingform.cpp
+++ b/src/data/records/gamesettingform.cpp
@@ -64,9 +64,13 @@ namespace esx
         }
         else if (ident == 's') {
             //TODO: Implement lstring check
-            quint32 index = r.read<quint32>();
-            QString lstring = r.lookupString("Skyrim.esm", index,
-                header.getType(), 'DATA');
+            if (r.isLocalizationEnabled()) {
+                quint32 index = r.read<quint32>();
+                QString lstring = r.lookupString("Skyrim.esm", index,
+                    header.getType(), 'DATA');
+            } else {
+                QString zstring = r.readZstring();
+            }
         }
     }
 

--- a/src/data/records/tes4form.cpp
+++ b/src/data/records/tes4form.cpp
@@ -49,6 +49,12 @@ namespace esx
      */
     void TES4Form::load(io::Reader& r)
     {
+        // Read flags.
+        if ((header.getFlags() & LOCALIZED) == LOCALIZED) {
+            r.setLocalizaton(true);
+        }
+
+        // Read subrecords.
         quint32 read = 0;
         while (read < header.getDataSize()) {
             SubrecordHeader h = readSubrecord(r, &read);

--- a/src/data/records/tes4form.h
+++ b/src/data/records/tes4form.h
@@ -62,6 +62,14 @@ namespace esx
         FORM_MEMBER(quint32, Incc)
 
     public:
+        enum Flags
+            : quint32
+        {
+            ESM = 0x00000001,
+            LOCALIZED = 0x00000080,
+            ESL = 0x00000200
+        };
+
         TES4Form() {}
         TES4Form(const Form &f);
         ~TES4Form() {}

--- a/src/io/reader.h
+++ b/src/io/reader.h
@@ -116,6 +116,25 @@ namespace io
         }
 
         /**
+         * Set the localization flag for subsequent reads. All lstrings replaced with zstrings when disabled.
+         * @brief Set localization flag.
+         * @param state of localization flag.
+         */
+        void setLocalizaton(bool enabled)
+        {
+            isLocalized = enabled;
+        }
+
+        /**
+         * Get the status of the localization flag.
+         * @return status of the localization flag.
+         */
+        bool isLocalizationEnabled() const
+        {
+            return isLocalized;
+        }
+
+        /**
          * Read a string of known length from the file stream.
          * @brief Read a string of known length.
          * @param size Length of string.
@@ -255,6 +274,12 @@ namespace io
          * @brief buffer Buffer to store data.
          */
         QByteArray buffer;
+
+        /**
+         * Set when flag in TES4 header has the localized strings bit set.
+         * @brief Localization enabled flag.
+         */
+        bool isLocalized{ false };
     };
 }
 

--- a/src/models/formmodel.cpp
+++ b/src/models/formmodel.cpp
@@ -1073,7 +1073,7 @@ namespace models
 
         item = item->child(item->childCount() - 1);
         item->setData(0, "Name");
-        item->setData(1, "Localised String: [" + QString::number(CLAS.getFullName()) + "]");
+        item->setData(1, "Localised String: [" + CLAS.getFullName() + "]");
 
         if (CLAS.getDesc() != 0) {
             rootItem->insertChildren(rootItem->childCount(), 1, 2);
@@ -1083,7 +1083,7 @@ namespace models
 
             item = item->child(item->childCount() - 1);
             item->setData(0, "Description");
-            item->setData(1, "Localised String: [" + QString::number(CLAS.getDesc()) + "]");
+            item->setData(1, "Localised String: [" + CLAS.getDesc() + "]");
         }
 
         if (CLAS.getIcon() != 0) {
@@ -1205,7 +1205,7 @@ namespace models
 
         item = item->child(item->childCount() - 1);
         item->setData(0, "Name");
-        item->setData(1, "Localised String: [" + QString::number(FACT.getFullName()) + "]");
+        item->setData(1, "Localised String: [" + FACT.getFullName() + "]");
 
         // Interfaction relations
         rootItem->insertChildren(rootItem->childCount(), 1, 2);


### PR DESCRIPTION
Added localization flag to the reader class that's pulled in from the TES4 header. Some temporary checks implemented so that non localized esm/esps can continue loading currently handled records.