### PR TITLE
Script Manager: Tab support. Model cleanup.

### DIFF
--- a/src/data/scriptmanagerdata.h
+++ b/src/data/scriptmanagerdata.h
@@ -1,3 +1,29 @@
+/*
+** scriptmanagerdata.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTMANAGERDATA_H
 #define SCRIPTMANAGERDATA_H
 

--- a/src/models/scriptcompilermodel.cpp
+++ b/src/models/scriptcompilermodel.cpp
@@ -1,11 +1,39 @@
+/*
+** scriptcompilermodel.cpp
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #include <models/scriptcompilermodel.h>
 #include <data/scriptmanagerdata.h>
+#include <QDebug>
 
 namespace models
 {
     ScriptCompilerModel::ScriptCompilerModel(QObject* parent)
         : QSortFilterProxyModel(parent)
     {
+        //setDynamicSortFilter(true);
     }
 
     bool ScriptCompilerModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
@@ -34,5 +62,27 @@ namespace models
         Q_UNUSED(tl);
         Q_UNUSED(br);
         invalidateFilter();
+        invalidate();
+    }
+
+    Qt::ItemFlags ScriptCompilerModel::flags(const QModelIndex& index) const
+    {
+        Qt::ItemFlags flags = sourceModel()->flags(mapToSource(index));
+        return flags;
+    }
+
+    bool ScriptCompilerModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int col, const QModelIndex& parent)
+    {
+        if (row == -1 && col == -1)
+            return sourceModel()->dropMimeData(data, action, -1, -1, mapToSource(parent));
+
+        if (sortOrder() == Qt::DescendingOrder) {
+            --row;
+        }
+
+        QModelIndex pIdx = index(row, col, parent);
+        QModelIndex sIdx = mapToSource(pIdx);
+
+        return this->sourceModel()->dropMimeData(data, action, sIdx.row(), sIdx.column(), sIdx.parent());
     }
 }

--- a/src/models/scriptcompilermodel.h
+++ b/src/models/scriptcompilermodel.h
@@ -1,3 +1,29 @@
+/*
+** scriptcompilermodel.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTCOMPILERMODEL_H
 #define SCRIPTCOMPILERMODEL_H
 
@@ -19,6 +45,9 @@ namespace models
         virtual bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
 
         virtual void setSourceModel(QAbstractItemModel* model) override;
+
+        virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
+        virtual bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int col, const QModelIndex& parent) override;
 
     private slots:
         void on_ScriptCompilerModel_dataChanged(const QModelIndex& tl, const QModelIndex& br);

--- a/src/models/scriptmanagermodel.cpp
+++ b/src/models/scriptmanagermodel.cpp
@@ -1,5 +1,33 @@
+/*
+** scriptmanagermodel.cpp
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #include <models/scriptmanagermodel.h>
 #include <QDebug>
+#include <QMimeData>
+#include <QDataStream>
 
 namespace models
 {
@@ -39,17 +67,19 @@ namespace models
         auto& scData = scriptData[index.row()];
         if (role == Qt::DisplayRole) {
             switch (index.column()) {
-            case 0: return scData.name;
-            case 1: return statusCodeToString(static_cast<int>(scData.status));
+            case COL_NAME: return scData.name;
+            case COL_TMPPATH: return scData.tmpPath;
+            case COL_STATUS: return statusCodeToString(static_cast<int>(scData.status));
+            case COL_PRIORITY: return QString::number(scData.priority);
             default: return {};
             }
         }
         else if (role == Qt::UserRole) {
             switch (index.column()) {
-            case 0: return scData.name;
-            case 1: return scData.tmpPath;
-            case 2: return static_cast<int>(scData.status);
-            case 3: return scData.priority;
+            case COL_NAME: return scData.name;
+            case COL_TMPPATH: return scData.tmpPath;
+            case COL_STATUS: return static_cast<int>(scData.status);
+            case COL_PRIORITY: return scData.priority;
             default: return {};
             }
         }
@@ -64,22 +94,43 @@ namespace models
             auto& scData = scriptData[index.row()];
             if (role == Qt::DisplayRole) {
                 switch (index.column()) {
-                case 0: scData.name = value.toString(); break;
-                case 1: scData.status = static_cast<ScriptStatus>(value.toInt()); break;
+                case COL_NAME: scData.name = value.toString(); break;
+                case COL_STATUS: scData.status = static_cast<ScriptStatus>(value.toInt()); break;
                 default: return false;
                 }
             }
             else if (role == Qt::UserRole) {
                 switch (index.column()) {
-                case 0: scData.name = value.toString(); break;
-                case 1: scData.tmpPath = value.toString(); break;
-                case 2: scData.status = static_cast<ScriptStatus>(value.toInt()); break;
-                case 3: scData.priority = value.toInt(); break;
+                case COL_NAME: scData.name = value.toString(); break;
+                case COL_TMPPATH: scData.tmpPath = value.toString(); break;
+                case COL_STATUS: 
+                {
+                    auto status = static_cast<ScriptStatus>(value.toInt()); 
+                    
+                    if (scData.status != ScriptStatus::COMPILE_WAIT && status == ScriptStatus::COMPILE_WAIT)
+                    {
+                        // Add to compile queue.
+                        int p = scriptDataIndices.size();
+                        scriptDataIndices.push_back(p);
+                        scData.priority = p;
+                    }
+                    else if(status != ScriptStatus::COMPILE_WAIT)
+                    {
+                        scData.priority = -1;
+                    }
+
+                    scData.status = status;
+
+                    break;
+                }
+                case COL_PRIORITY: scData.priority = value.toInt(); break;
                 default: return false;
                 }
             }
 
-            emit dataChanged(index, index);
+            QModelIndex tl = createIndex(index.row(), COL_NAME);
+            QModelIndex br = createIndex(index.row(), COL_PRIORITY);
+            emit dataChanged(tl, br);
             return true;
         }
 
@@ -90,11 +141,137 @@ namespace models
     {
         if (role == Qt::DisplayRole) {
             switch (section) {
-            case 0: return "Name";
-            case 1: return "Status";
+            case COL_NAME: return "Name";
+            case COL_TMPPATH: return "Temp Path";
+            case COL_STATUS: return "Status";
+            case COL_PRIORITY: return "Priority";
             }
         }
         return {};
+    }
+
+    Qt::ItemFlags ScriptManagerModel::flags(const QModelIndex& index) const
+    {
+        Qt::ItemFlags result = QAbstractItemModel::flags(index);
+
+        if (index.model() < 0) {
+            return Qt::ItemIsEnabled;
+        }
+
+        return result | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled | Qt::ItemIsDropEnabled;
+    }
+
+    Qt::DropActions ScriptManagerModel::supportedDropActions() const
+    {
+        return Qt::MoveAction;
+    }
+
+    QMimeData* ScriptManagerModel::mimeData(const QModelIndexList& indices) const
+    {
+        QMimeData* mimeData = QAbstractItemModel::mimeData(indices);
+        mimeData->setData("text/plain", "item");
+        return mimeData;
+    }
+
+    bool ScriptManagerModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int col, const QModelIndex& parent)
+    {
+        if (action == Qt::IgnoreAction)
+            return true;
+
+        if (data->hasText()) {
+            return dropItem(data, row, parent);
+        }
+
+        return false;
+    }
+
+    bool ScriptManagerModel::dropItem(const QMimeData* mimeData, int row, const QModelIndex& parent)
+    {
+        try {
+
+            QByteArray encoded = mimeData->data("application/x-qabstractitemmodeldatalist");
+            QDataStream stream(&encoded, QIODevice::ReadOnly);
+
+            // Decode information of the dropped item.
+            std::vector<int> srcRows;
+            while (!stream.atEnd()) {
+                int srcRow, col;
+                QMap<int, QVariant> roleMap;
+                stream >> srcRow >> col >> roleMap;
+                if (col == 0) {
+                    srcRows.push_back(srcRow);
+                }
+            }
+
+            // row contains the position of where the drop was complete.
+            //qDebug() << "Drop row: " << row << " from row: " << srcRows[0];
+
+            if (row == -1) {
+                row = parent.row();
+            }
+
+            if (row < 0 || row >= scriptData.size())
+                return false;
+
+            //auto sr = index(srcRows[0], 3);
+            //auto dr = index(row, 3);
+            auto& sr = scriptData[srcRows[0]];
+            auto& dr = scriptData[row];
+
+            // pull indices and sort to temporary.
+            // TODO: Cache indices instead.
+            QVector<ScriptManagerData*> indices;
+            for (auto& item : scriptData) {
+                if (item.status == ScriptStatus::COMPILE_WAIT) {
+                    indices.push_back(&item);
+                }
+            }
+
+            // We need to check if we are going below or above.
+            if (sr.priority < dr.priority) {
+
+                qSort(indices.begin(), indices.end(), [](ScriptManagerData* lhs, ScriptManagerData* rhs) {
+                    return lhs->priority > rhs->priority;
+                });
+                // Set our source to the drop priority.
+                sr.priority = dr.priority;
+
+                int nextIndex = sr.priority - 1;
+                for (auto* item : indices) {
+                    if (item->priority <= sr.priority && (item != &sr)) {
+                        item->priority = nextIndex;
+                        nextIndex--;
+                    }
+                }
+            }
+            else
+            {
+                qSort(indices.begin(), indices.end(), [](ScriptManagerData* lhs, ScriptManagerData* rhs) {
+                    return lhs->priority < rhs->priority;
+                });
+                // Set our source to the drop priority.
+                sr.priority = dr.priority;
+
+                // Iterate items to recalculate priority.
+                int nextIndex = sr.priority + 1;
+                for (auto* item : indices) {
+                    if (item->priority >= sr.priority && (item != &sr)) {
+                        
+                        item->priority = nextIndex;
+                        nextIndex++;
+                    }
+                }
+            }
+
+            QModelIndex top = createIndex(scriptData.size() - 1, 0);
+            QModelIndex bottom = createIndex(scriptData.size() - 1, 3);
+            emit dataChanged(top, bottom);
+        }
+        catch (const std::exception& e)
+        {
+            return false;
+        }
+        return false;
     }
 
     bool ScriptManagerModel::insertRows(int row, int count, const QModelIndex& parent)
@@ -102,6 +279,8 @@ namespace models
         beginInsertRows({}, row, row + (count - 1));
         scriptData.insert(row, count, {});
         endInsertRows();
+
+        //updateScriptDataIndices();
 
         return true;
     }
@@ -111,6 +290,8 @@ namespace models
         beginRemoveRows({}, row, row + (count - 1));
         scriptData.remove(row, count);
         endRemoveRows();
+
+        //updateScriptDataIndices();
 
         return true;
     }

--- a/src/models/scriptmanagermodel.h
+++ b/src/models/scriptmanagermodel.h
@@ -1,3 +1,29 @@
+/*
+** scriptmanagermodel.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTMANAGERMODEL_H
 #define SCRIPTMANAGERMODEL_H
 
@@ -9,6 +35,14 @@ namespace models
     class ScriptManagerModel : public QAbstractItemModel
     {
     public:
+        enum ColumnType
+        {
+            COL_NAME,
+            COL_TMPPATH,
+            COL_STATUS,
+            COL_PRIORITY
+        };
+
         ScriptManagerModel(QObject* parent = Q_NULLPTR);
         ScriptManagerModel(const ScriptManagerModel&) = default;
         ScriptManagerModel& operator=(const ScriptManagerModel&) = default;
@@ -23,15 +57,23 @@ namespace models
 
         virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
+        // Drag drop functionality.
+        virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
+        virtual Qt::DropActions supportedDropActions() const override;
+        //virtual QStringList mimeTypes() const override;
+        virtual QMimeData* mimeData(const QModelIndexList& indices) const override;
+        virtual bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int col, const QModelIndex& parent) override;
+
         virtual bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
         virtual bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
-        void AddNewScript(const QString& name);
-
     private:
         QVector<ScriptManagerData> scriptData;
+        QVector<int> scriptDataIndices;
 
         QString statusCodeToString(int code) const;
+
+        bool dropItem(const QMimeData* mimeData, int row, const QModelIndex& parent);
     };
 }
 

--- a/src/ui/scriptmanagertab.cpp
+++ b/src/ui/scriptmanagertab.cpp
@@ -46,8 +46,8 @@ ScriptManagerTab::ScriptManagerTab(QWidget* parent)
 
     auto* managerTree = ui->treeViewScripts;
     managerTree->setModel(managerProxyModel);
-    managerTree->hideColumn(2);
-    managerTree->hideColumn(3);
+    managerTree->hideColumn(models::ScriptManagerModel::COL_TMPPATH);
+    managerTree->hideColumn(models::ScriptManagerModel::COL_PRIORITY);
 
     // Setup compiler model.
     compilerModel = new models::ScriptCompilerModel(this);
@@ -55,13 +55,19 @@ ScriptManagerTab::ScriptManagerTab(QWidget* parent)
 
     auto* compilerTree = ui->treeViewScriptsCompile;
     compilerTree->setModel(compilerModel);
-    compilerTree->hideColumn(2);
-    compilerTree->hideColumn(3);
+    compilerTree->hideColumn(models::ScriptManagerModel::COL_TMPPATH);
+    compilerTree->hideColumn(models::ScriptManagerModel::COL_STATUS);
+    compilerTree->hideColumn(models::ScriptManagerModel::COL_PRIORITY);
+    compilerTree->sortByColumn(3, Qt::SortOrder::AscendingOrder);
 
     //TODO: Remove temp.
     connect(ui->treeViewScripts, SIGNAL(scriptIndexChanged(int)), ui->plainTextEditScriptEditor, SLOT(on_scriptIndexChanged(int)));
 }
 
+/**
+* Called when the return key is pressed whilst the script filter line edit is active.
+* @brief Handle return key for script filter.
+*/
 void ScriptManagerTab::on_lineEditScriptFilter_returnPressed()
 {
     if (managerProxyModel) {
@@ -69,6 +75,10 @@ void ScriptManagerTab::on_lineEditScriptFilter_returnPressed()
     }
 }
 
+/**
+* Called when the clear button is pressed in the script filter line edit.
+* @brief Clear filter line edit.
+*/
 void ScriptManagerTab::on_lineEditScriptFilter_clearButtonClicked()
 {
     if (managerProxyModel) {

--- a/src/ui/scriptmanagertab.cpp
+++ b/src/ui/scriptmanagertab.cpp
@@ -30,6 +30,8 @@
 #include <models/scriptmanagermodel.h>
 #include <models/scriptcompilermodel.h>
 
+#include <widgets/scripteditor.h>
+
 #include <QDebug>
 #include <QSortFilterProxyModel>
 #include <QFileSystemWatcher>
@@ -64,7 +66,7 @@ ScriptManagerTab::ScriptManagerTab(QWidget* parent)
     compilerTree->sortByColumn(3, Qt::SortOrder::AscendingOrder);
 
     //TODO: Remove temp.
-    connect(ui->treeViewScripts, SIGNAL(scriptIndexChanged(int)), ui->plainTextEditScriptEditor, SLOT(on_scriptIndexChanged(int)));
+    //connect(ui->treeViewScripts, SIGNAL(scriptIndexChanged(int)), ui->plainTextEditScriptEditor, SLOT(on_scriptIndexChanged(int)));
 
     // Pull in data.
     //QDir scriptFolder("data/source");
@@ -111,4 +113,37 @@ void ScriptManagerTab::on_pushButtonCompile_released()
 
         //TODO: Hook up papyrus compiler when settings available.
     }
+}
+
+void ScriptManagerTab::on_treeViewScripts_doubleClicked(const QModelIndex& index)
+{
+    if (!index.isValid())
+        return;
+
+    QString scriptName = managerProxyModel->data(index, Qt::UserRole).toString();
+
+    // Search for an active editor before creating a new one.
+    auto* tabBar = ui->tabWidgetScriptEditor->tabBar();
+    int numTabs = tabBar->count();
+    int foundIndex = -1;
+    for (int i = 0; i < numTabs && foundIndex == -1; i++) {
+        if (tabBar->tabText(i) == scriptName) {
+            foundIndex = i;
+        }
+    }
+
+    if (foundIndex != -1) {
+        // Switch to active tab.
+        ui->tabWidgetScriptEditor->setCurrentIndex(foundIndex);
+    } else {
+        // Create a new tab
+        ui->tabWidgetScriptEditor->addTab(new ScriptEditor(ui->tabWidgetScriptEditor), scriptName);
+    }
+}
+
+void ScriptManagerTab::on_tabWidgetScriptEditor_tabCloseRequested(int index)
+{
+    // TODO: Prompt user when contents changed in widget.
+    // Remove tab from stack and delete it.
+    ui->tabWidgetScriptEditor->widget(index)->deleteLater();
 }

--- a/src/ui/scriptmanagertab.h
+++ b/src/ui/scriptmanagertab.h
@@ -66,6 +66,8 @@ private:
     QSortFilterProxyModel* managerProxyModel{ nullptr };
     models::ScriptManagerModel* managerModel{ nullptr };
     models::ScriptCompilerModel* compilerModel{ nullptr };
+
+    QString scriptsPath;
 };
 
 #endif

--- a/src/ui/scriptmanagertab.h
+++ b/src/ui/scriptmanagertab.h
@@ -1,3 +1,29 @@
+/*
+** scriptmanagertab.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTMANAGERTAB_H
 #define SCRIPTMANAGERTAB_H
 
@@ -15,8 +41,7 @@ namespace models
 }
 
 class QSortFilterProxyModel;
-class ScriptManagerTab
-    : public QWidget
+class ScriptManagerTab : public QWidget
 {
     Q_OBJECT
 public:

--- a/src/ui/scriptmanagertab.h
+++ b/src/ui/scriptmanagertab.h
@@ -55,6 +55,9 @@ private slots:
     void on_lineEditScriptFilter_clearButtonClicked();
     void on_pushButtonCompile_released();
 
+    void on_treeViewScripts_doubleClicked(const QModelIndex& index);
+    void on_tabWidgetScriptEditor_tabCloseRequested(int index);
+
 private:
     Ui::ScriptManagerTab* ui;
 

--- a/src/ui/scriptmanagertab.h
+++ b/src/ui/scriptmanagertab.h
@@ -53,6 +53,7 @@ public:
 private slots:
     void on_lineEditScriptFilter_returnPressed();
     void on_lineEditScriptFilter_clearButtonClicked();
+    void on_pushButtonCompile_released();
 
 private:
     Ui::ScriptManagerTab* ui;

--- a/src/ui/scriptmanagertab.h
+++ b/src/ui/scriptmanagertab.h
@@ -56,12 +56,15 @@ private slots:
     void on_pushButtonCompile_released();
 
     void on_treeViewScripts_doubleClicked(const QModelIndex& index);
+    void on_treeViewScripts_newScriptTriggered(bool);
+
     void on_tabWidgetScriptEditor_tabCloseRequested(int index);
 
 private:
     Ui::ScriptManagerTab* ui;
 
     QSortFilterProxyModel* managerProxyModel{ nullptr };
+    models::ScriptManagerModel* managerModel{ nullptr };
     models::ScriptCompilerModel* compilerModel{ nullptr };
 };
 

--- a/src/ui/scriptmanagertab.ui
+++ b/src/ui/scriptmanagertab.ui
@@ -31,6 +31,9 @@
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
+      <property name="handleWidth">
+       <number>4</number>
+      </property>
       <widget class="QWidget" name="layoutWidget_3">
        <layout class="QVBoxLayout" name="verticalLayout_1" stretch="0,0">
         <property name="spacing">

--- a/src/ui/scriptmanagertab.ui
+++ b/src/ui/scriptmanagertab.ui
@@ -92,6 +92,9 @@
           <property name="itemsExpandable">
            <bool>false</bool>
           </property>
+          <property name="sortingEnabled">
+           <bool>true</bool>
+          </property>
           <property name="headerHidden">
            <bool>false</bool>
           </property>
@@ -183,6 +186,9 @@
        </sizepolicy>
       </property>
       <property name="tabsClosable">
+       <bool>true</bool>
+      </property>
+      <property name="movable">
        <bool>true</bool>
       </property>
      </widget>

--- a/src/ui/scriptmanagertab.ui
+++ b/src/ui/scriptmanagertab.ui
@@ -175,18 +175,15 @@
        </layout>
       </widget>
      </widget>
-     <widget class="ScriptEditor" name="plainTextEditScriptEditor">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
+     <widget class="QTabWidget" name="tabWidgetScriptEditor">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>1</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="styleSheet">
-       <string notr="true"/>
+      <property name="tabsClosable">
+       <bool>true</bool>
       </property>
      </widget>
     </widget>
@@ -194,11 +191,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ScriptEditor</class>
-   <extends>QPlainTextEdit</extends>
-   <header>widgets/scripteditor.h</header>
-  </customwidget>
   <customwidget>
    <class>ScriptTreeView</class>
    <extends>QTreeView</extends>

--- a/src/views/scriptcompiletreeview.cpp
+++ b/src/views/scriptcompiletreeview.cpp
@@ -1,5 +1,79 @@
+/*
+** scriptcompiletreeview.cpp
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #include <views/scriptcompiletreeview.h>
+#include <data/scriptmanagerdata.h>
 #include <QDropEvent>
+#include <QMimeData>
+#include <QMenu>
+#include <QProxyStyle>
+#include <QPen>
+#include <QPainter>
+#include <QStyleOption>
+#include <QDebug>
+
+#include <qsortfilterproxymodel.h>
+
+class ScriptCompileStyleProxy : public QProxyStyle
+{
+public:
+    ScriptCompileStyleProxy(QStyle* style = Q_NULLPTR);
+
+    virtual void drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget = Q_NULLPTR) const override;
+};
+
+ScriptCompileStyleProxy::ScriptCompileStyleProxy(QStyle* style)
+    : QProxyStyle(style)
+{
+}
+
+/**
+* Proxy changes the default style of the drop indicator to a solid black underline.
+* @brief Changes drop indicator style.
+*/
+void ScriptCompileStyleProxy::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const
+{
+    if (element == QStyle::PE_IndicatorItemViewItemDrop && !option->rect.isNull()) {
+        
+        if (widget) {
+            QStyleOption opt(*option);
+            opt.rect.setLeft(0);
+
+            QColor c(Qt::black);
+            QPen pen(c);
+            pen.setWidth(2);
+            painter->setPen(pen);
+
+            painter->drawLine(option->rect.bottomLeft(), option->rect.bottomRight());
+        }
+        return;
+    }
+
+    QProxyStyle::drawPrimitive(element, option, painter, widget);
+}
 
 ScriptCompileTreeView::ScriptCompileTreeView(QWidget* parent)
     : QTreeView(parent)
@@ -10,8 +84,14 @@ ScriptCompileTreeView::ScriptCompileTreeView(QWidget* parent)
     // Drag and Drop functionality.
     setDragEnabled(true);
     viewport()->setAcceptDrops(true);
-    setDropIndicatorShown(true);
+    //setDropIndicatorShown(true);
     setDragDropMode(QAbstractItemView::InternalMove);
+    setSelectionMode(QAbstractItemView::SingleSelection);
+    setSelectionBehavior(QAbstractItemView::SelectRows);
+    setDragDropOverwriteMode(false);
+
+    // Set custom style. Overrides the horrible looking drop indicator.
+    setStyle(new ScriptCompileStyleProxy(style()));
 }
 
 void ScriptCompileTreeView::initActions()
@@ -19,17 +99,37 @@ void ScriptCompileTreeView::initActions()
 
 }
 
+/**
+* Shows context menu related to compiler queue items.
+* @brief Show compiler context menu.
+*/
 void ScriptCompileTreeView::showContextMenu(const QPoint& pos)
 {
-    
+    QMenu menu(tr(""), this);
+
+    auto index = indexAt(pos);
+
+    if (index.isValid()) {
+
+        auto c = model()->index(index.row(), 2);
+        model()->setData(c, static_cast<int>(ScriptStatus::NONE), Qt::UserRole);
+
+    }
+
+    menu.exec();
 }
 
-void ScriptCompileTreeView::dropEvent(QDropEvent* ev)
+/**
+* Sets the underlying model of this tree view with additional options for selection and drag-drop.
+* @brief Sets underlying model.
+*/
+void ScriptCompileTreeView::setModel(QAbstractItemModel* model)
 {
-    QModelIndex dropIdx = indexAt(ev->pos());
-
-    if (!dropIdx.isValid())
-        return;
-
-    QTreeView::dropEvent(ev);
+    QTreeView::setModel(model);
+    setDragDropMode(QAbstractItemView::InternalMove);
+    setSelectionMode(QAbstractItemView::SingleSelection);
+    setSelectionBehavior(QAbstractItemView::SelectRows);
+    setDragEnabled(true);
+    viewport()->setAcceptDrops(true);
+    setDragDropOverwriteMode(false);
 }

--- a/src/views/scriptcompiletreeview.cpp
+++ b/src/views/scriptcompiletreeview.cpp
@@ -96,7 +96,7 @@ ScriptCompileTreeView::ScriptCompileTreeView(QWidget* parent)
 
 void ScriptCompileTreeView::initActions()
 {
-
+    removeScriptAction = new QAction("Remove from queue", this);
 }
 
 /**
@@ -113,6 +113,8 @@ void ScriptCompileTreeView::showContextMenu(const QPoint& pos)
 
         auto c = model()->index(index.row(), 2);
         model()->setData(c, static_cast<int>(ScriptStatus::NONE), Qt::UserRole);
+
+        menu.addAction(removeScriptAction);
 
     }
 

--- a/src/views/scriptcompiletreeview.h
+++ b/src/views/scriptcompiletreeview.h
@@ -48,6 +48,8 @@ private slots:
 
 private:
     void initActions();
+
+    QAction* removeScriptAction{ nullptr };
 };
 
 #endif

--- a/src/views/scriptcompiletreeview.h
+++ b/src/views/scriptcompiletreeview.h
@@ -1,3 +1,29 @@
+/*
+** scriptcompiletreeview.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTCOMPILETREEVIEW_H
 #define SCRIPTCOMPILETREEVIEW_H
 
@@ -12,13 +38,16 @@ public:
     ScriptCompileTreeView& operator=(const ScriptCompileTreeView&) = default;
     ~ScriptCompileTreeView() = default;
 
+    virtual void setModel(QAbstractItemModel* model) override;
+
+protected:
+    //virtual void drawPrimitive(QStyle::PrimitiveElement elem, const QStyleOption* option, QPainter* painter, const QWidget* widget = Q_NULLPTR) const override;
+
 private slots:
     void showContextMenu(const QPoint& pos);
 
 private:
     void initActions();
-
-    virtual void dropEvent(QDropEvent* ev) override;
 };
 
 #endif

--- a/src/views/scripttreeview.cpp
+++ b/src/views/scripttreeview.cpp
@@ -1,3 +1,29 @@
+/*
+** scripttreeview.cpp
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #include <views/scripttreeview.h>
 #include <QMenu>
 #include <QInputDialog>
@@ -24,6 +50,10 @@ void ScriptTreeView::setModel(QAbstractItemModel* model)
     connect(selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this, SLOT(on_ScriptTreeView_selectionChanged(const QItemSelection&, const QItemSelection&)));
 }
 
+/**
+* Shows context menu related to script items or global options when no item present under cursor.
+* @brief Shows context menu related to scripts.
+*/
 void ScriptTreeView::showContextMenu(const QPoint& pos)
 {
     QMenu menu(tr(""), this);
@@ -53,6 +83,10 @@ void ScriptTreeView::showContextMenu(const QPoint& pos)
     menu.exec(mapToGlobal(pos));
 }
 
+/**
+* Initialize and connect context menu actions.
+* @brief Initialize and connect context menu actions.
+*/
 void ScriptTreeView::initActions()
 {
     // Per item actions
@@ -72,21 +106,26 @@ void ScriptTreeView::initActions()
     connect(newScriptAction, SIGNAL(triggered(bool)), this, SLOT(on_newScriptAction_triggered(bool)));
 }
 
+/**
+* Called when compile option is selected in context menu. Adds item to compilation queue.
+* @brief Add item to compilation queue.
+*/
 void ScriptTreeView::on_compileAction_triggered(bool /* checked */)
 {
     auto* cModel = model();
     if (cModel) {
 
         QModelIndex index = compileAction->data().toModelIndex();
-        
         QModelIndex statusIndex = cModel->index(index.row(), 2);
-        QModelIndex priorityIndex = cModel->index(index.row(), 3);
         
         cModel->setData(statusIndex, static_cast<int>(2), Qt::UserRole);
-        cModel->setData(priorityIndex, 0, Qt::UserRole);
     }
 }
 
+/**
+* Called when 'New script' option selected in context menu. Opens a dialog to create a new script file.
+* @brief Create new script file.
+*/
 void ScriptTreeView::on_newScriptAction_triggered(bool /* checked */)
 {
     auto* cModel = static_cast<QSortFilterProxyModel*>(model())->sourceModel();
@@ -104,6 +143,10 @@ void ScriptTreeView::on_newScriptAction_triggered(bool /* checked */)
     }
 }
 
+/**
+* Called when 'Rename script' option selected in context menu. Opens a dialog for renaming script file.
+* @brief Rename script file.
+*/
 void ScriptTreeView::on_renameScriptAction_triggered(bool /* checked */)
 {
     auto* cModel = model();
@@ -121,6 +164,10 @@ void ScriptTreeView::on_renameScriptAction_triggered(bool /* checked */)
     }
 }
 
+/**
+* Called when 'Delete script' option selected in context menu. Prompts user if wanting to delete script file.
+* @brief Delete script file.
+*/
 void ScriptTreeView::on_deleteScriptAction_triggered(bool /* checked */)
 {
     auto* cModel = model();
@@ -139,6 +186,10 @@ void ScriptTreeView::on_deleteScriptAction_triggered(bool /* checked */)
     }
 }
 
+/**
+* Called when an item is double clicked in the view.
+* @brief Item double click handler.
+*/
 void ScriptTreeView::on_ScriptTreeView_doubleClicked(const QModelIndex& index)
 {
     auto* cModel = model();
@@ -149,6 +200,10 @@ void ScriptTreeView::on_ScriptTreeView_doubleClicked(const QModelIndex& index)
     }
 }
 
+/**
+* Called when the selection index is changed within in the view.
+* @brief Selection changed handler.
+*/
 void ScriptTreeView::on_ScriptTreeView_selectionChanged(const QItemSelection&, const QItemSelection&)
 {
     //TODO: Temp code before proper filesystem integration. Remove when exists.

--- a/src/views/scripttreeview.cpp
+++ b/src/views/scripttreeview.cpp
@@ -41,14 +41,6 @@ ScriptTreeView::ScriptTreeView(QWidget* parent)
 
     this->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenu(const QPoint&)));
-    connect(this, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(on_ScriptTreeView_doubleClicked(const QModelIndex&)));
-}
-
-void ScriptTreeView::setModel(QAbstractItemModel* model)
-{
-    QTreeView::setModel(model);
-
-    connect(selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this, SLOT(on_ScriptTreeView_selectionChanged(const QItemSelection&, const QItemSelection&)));
 }
 
 /**
@@ -102,9 +94,9 @@ void ScriptTreeView::initActions()
     deleteScriptAction = new QAction(tr("Delete script"), this);
     connect(deleteScriptAction, SIGNAL(triggered(bool)), this, SLOT(on_deleteScriptAction_triggered(bool)));
 
-    // Global actions.
+    // Global actions. Forwarded to external signals.
     newScriptAction = new QAction(tr("New script"), this);
-    connect(newScriptAction, SIGNAL(triggered(bool)), this, SLOT(on_newScriptAction_triggered(bool)));
+    connect(newScriptAction, SIGNAL(triggered(bool)), this, SIGNAL(newScriptTriggered(bool)));
 }
 
 /**
@@ -120,27 +112,6 @@ void ScriptTreeView::on_compileAction_triggered(bool /* checked */)
         QModelIndex statusIndex = cModel->index(index.row(), 2);
         
         cModel->setData(statusIndex, static_cast<int>(2), Qt::UserRole);
-    }
-}
-
-/**
-* Called when 'New script' option selected in context menu. Opens a dialog to create a new script file.
-* @brief Create new script file.
-*/
-void ScriptTreeView::on_newScriptAction_triggered(bool /* checked */)
-{
-    auto* cModel = static_cast<QSortFilterProxyModel*>(model())->sourceModel();
-    if (cModel) {
-        bool ok;
-        QString scriptName = QInputDialog::getText(this, tr("New script"), tr("Script Name"), QLineEdit::Normal, "", &ok);
-
-        if (ok && !scriptName.isEmpty()) {
-            //TODO: Check for duplicate. Create script otherwise.
-
-            int rc = cModel->rowCount();
-            cModel->insertRow(rc);
-            cModel->setData(cModel->index(rc, 0), scriptName, Qt::DisplayRole);
-        }
     }
 }
 
@@ -184,37 +155,5 @@ void ScriptTreeView::on_deleteScriptAction_triggered(bool /* checked */)
             int row = index.row();
             cModel->removeRow(row);
         }
-    }
-}
-
-/**
-* Called when an item is double clicked in the view.
-* @brief Item double click handler.
-*/
-void ScriptTreeView::on_ScriptTreeView_doubleClicked(const QModelIndex& index)
-{
-    auto* cModel = model();
-    if (cModel) {
-
-        //ScriptEditor* editor = new ScriptEditor()
-
-
-        //TODO: Temp code before proper filesystem integration. Remove when exists.
-        emit scriptIndexChanged((index.isValid() ? 0 : -1));
-    }
-}
-
-/**
-* Called when the selection index is changed within in the view.
-* @brief Selection changed handler.
-*/
-void ScriptTreeView::on_ScriptTreeView_selectionChanged(const QItemSelection&, const QItemSelection&)
-{
-    //TODO: Temp code before proper filesystem integration. Remove when exists.
-    auto* cModel = model();
-    if (cModel) {
-
-        if(!currentIndex().isValid())
-            emit scriptIndexChanged(-1);
     }
 }

--- a/src/views/scripttreeview.cpp
+++ b/src/views/scripttreeview.cpp
@@ -25,6 +25,7 @@
 */
 
 #include <views/scripttreeview.h>
+#include <widgets/scripteditor.h>
 #include <QMenu>
 #include <QInputDialog>
 #include <QMessageBox>
@@ -194,6 +195,9 @@ void ScriptTreeView::on_ScriptTreeView_doubleClicked(const QModelIndex& index)
 {
     auto* cModel = model();
     if (cModel) {
+
+        //ScriptEditor* editor = new ScriptEditor()
+
 
         //TODO: Temp code before proper filesystem integration. Remove when exists.
         emit scriptIndexChanged((index.isValid() ? 0 : -1));

--- a/src/views/scripttreeview.h
+++ b/src/views/scripttreeview.h
@@ -1,3 +1,29 @@
+/*
+** scripttreeview.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTTREEVIEW_H
 #define SCRIPTTREEVIEW_H
 

--- a/src/views/scripttreeview.h
+++ b/src/views/scripttreeview.h
@@ -38,22 +38,16 @@ public:
     ScriptTreeView& operator=(const ScriptTreeView&) = default;
     ~ScriptTreeView() = default;
 
-    virtual void setModel(QAbstractItemModel* model) override;
-
 private slots:
     void showContextMenu(const QPoint& pos);
     
     void on_compileAction_triggered(bool);
 
-    void on_newScriptAction_triggered(bool);
     void on_renameScriptAction_triggered(bool);
     void on_deleteScriptAction_triggered(bool);
 
-    void on_ScriptTreeView_doubleClicked(const QModelIndex& index);
-    void on_ScriptTreeView_selectionChanged(const QItemSelection&, const QItemSelection&);
-
 signals:
-    void scriptIndexChanged(int index);
+    void newScriptTriggered(bool);
 
 private:
     void initActions();

--- a/src/widgets/clearablelineedit.cpp
+++ b/src/widgets/clearablelineedit.cpp
@@ -1,3 +1,29 @@
+/*
+** clearablelineedit.cpp
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #include <widgets/clearablelineedit.h>
 #include <QToolButton>
 #include <QStyle>

--- a/src/widgets/clearablelineedit.h
+++ b/src/widgets/clearablelineedit.h
@@ -1,3 +1,29 @@
+/*
+** clearablelineedit.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef CLEARABLELINEEDIT_H
 #define CLEARABLELINEEDIT_H
 

--- a/src/widgets/papyrushighlighter.cpp
+++ b/src/widgets/papyrushighlighter.cpp
@@ -45,6 +45,7 @@ PapyrusHighlighter::PapyrusHighlighter(QTextDocument* parent)
     keywords << "\\bIf\\b" << "\\bElse\\b" << "\\bElseIf\\b" << "\\bEndIf\\b" << "\\bWhile\\b" << "\\bEndWhile\\b";
 
     // Classes
+    // TODO: Replace if/when parser available. These are all scripts.
     keywords << "\\bActor\\b";
 
     for (auto& keyword : keywords) {

--- a/src/widgets/papyrushighlighter.cpp
+++ b/src/widgets/papyrushighlighter.cpp
@@ -70,7 +70,7 @@ PapyrusHighlighter::PapyrusHighlighter(QTextDocument* parent)
 
     // Commenting
     commentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = QRegularExpression(";[^\\n]*|(\\{(.*?)\\})"); //;[^\n]*
+    rule.pattern = QRegularExpression("(;[^\\n]*|(\\{([^\\}]*?)\\}))(?=[^\"]*(?:\"[^\"]*\"[^\"]*)*$)"); //R1: (;[^\\n]*|(\\{(.*?)\\}))
     rule.format = commentFormat;
     rules.append(rule);
 

--- a/src/widgets/papyrushighlighter.cpp
+++ b/src/widgets/papyrushighlighter.cpp
@@ -64,15 +64,18 @@ PapyrusHighlighter::PapyrusHighlighter(QTextDocument* parent)
 
     // String literals.
     stringLiteralFormat.setForeground(Qt::darkRed);
-    rule.pattern = QRegularExpression("\".*\"");
+    rule.pattern = QRegularExpression("\"(.*?)\"");
     rule.format = stringLiteralFormat;
     rules.append(rule);
 
     // Commenting
     commentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = QRegularExpression(";[^\n]*");
+    rule.pattern = QRegularExpression(";[^\\n]*|(\\{(.*?)\\})"); //;[^\n]*
     rule.format = commentFormat;
     rules.append(rule);
+
+    // Selected word highlight
+    selectedTextBackground = QBrush(QColor{0, 0, 150, 150});
 }
 
 void PapyrusHighlighter::highlightBlock(const QString& text)
@@ -81,6 +84,7 @@ void PapyrusHighlighter::highlightBlock(const QString& text)
         QRegularExpressionMatchIterator it = rule.pattern.globalMatch(text);
         while (it.hasNext()) {
             QRegularExpressionMatch match = it.next();
+
             setFormat(match.capturedStart(), match.capturedLength(), rule.format);
         }
     }

--- a/src/widgets/papyrushighlighter.cpp
+++ b/src/widgets/papyrushighlighter.cpp
@@ -1,3 +1,29 @@
+/*
+** papyrushighlighter.cpp
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #include <widgets/papyrushighlighter.h>
 
 PapyrusHighlighter::PapyrusHighlighter(QTextDocument* parent)
@@ -29,9 +55,9 @@ PapyrusHighlighter::PapyrusHighlighter(QTextDocument* parent)
 
     // Number literals.
     QBrush numLiteralBrush(QColor(181, 106, 168));
-    numberLiteralFormat.setForeground(numLiteralBrush);
-    rule.pattern = QRegularExpression("\\b(([+-]?\\d*(\\.|,)?\\d+([eE][+-]?\\d+)?)(?![A-Za-z0-9.]))");
 
+    numberLiteralFormat.setForeground(numLiteralBrush);
+    rule.pattern = QRegularExpression("\\b[+-]?[0-9]+(?:.[0-9]+)?(?:[eE][+-]?[0-9]+)?\\b", QRegularExpression::MultilineOption); //\b[+-]?[0-9]+(?:.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b //\\b(([+-]?\\d*(\\.|,)?\\d+([eE][+-]?\\d+)?)(?![A-Za-z0-9.]))
     rule.format = numberLiteralFormat;
     rules.append(rule);
 

--- a/src/widgets/papyrushighlighter.h
+++ b/src/widgets/papyrushighlighter.h
@@ -52,6 +52,9 @@ private:
     QTextCharFormat commentFormat;
     QTextCharFormat stringLiteralFormat;
     QTextCharFormat numberLiteralFormat;
+
+    QBrush selectedTextBackground;
+    QString selectedText;
 };
 
 #endif

--- a/src/widgets/papyrushighlighter.h
+++ b/src/widgets/papyrushighlighter.h
@@ -1,3 +1,29 @@
+/*
+** papyrushighlighter.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef PAPYRUSHIGHLIGHTER_H
 #define PAPYRUSHIGHLIGHTER_H
 

--- a/src/widgets/scripteditor.cpp
+++ b/src/widgets/scripteditor.cpp
@@ -141,13 +141,13 @@ int ScriptEditor::getLineNumberAreaWidth() const
     return space;
 }
 
-void ScriptEditor::on_scriptIndexChanged(int index)
+/*void ScriptEditor::on_scriptIndexChanged(int index)
 {
     this->setEnabled((index == -1) ? false : true);
 
     if (index == -1)
         clear();
-}
+}*/
 
 /**
 * Takes user input and moves the text cursor to the specified line.

--- a/src/widgets/scripteditor.cpp
+++ b/src/widgets/scripteditor.cpp
@@ -28,9 +28,10 @@
 #include <widgets/papyrushighlighter.h>
 #include <QPainter>
 #include <QTextBlock>
+#include <QTextStream>
 #include <QInputDialog>
 
-ScriptEditor::ScriptEditor(QWidget* parent)
+ScriptEditor::ScriptEditor(QString filename, QWidget* parent)
     : QPlainTextEdit(parent)
 {
     setWordWrapMode(QTextOption::NoWrap);
@@ -43,6 +44,13 @@ ScriptEditor::ScriptEditor(QWidget* parent)
     syntaxHighlighter = new PapyrusHighlighter(document());
 
     this->setTabStopWidth(4 * fontMetrics().width(' '));
+
+    // Load in file.
+    QFile file(filename);
+    file.open(QIODevice::ReadOnly);
+    QTextStream fs(&file);
+    this->document()->setPlainText(fs.readAll());
+    moveCursor(QTextCursor::Start);
 }
 
 void ScriptEditor::resizeEvent(QResizeEvent* ev)

--- a/src/widgets/scripteditor.h
+++ b/src/widgets/scripteditor.h
@@ -34,7 +34,7 @@ class ScriptEditor : public QPlainTextEdit
 {
     Q_OBJECT
 public:
-    ScriptEditor(QWidget* parent = Q_NULLPTR);
+    ScriptEditor(QString filename, QWidget* parent = Q_NULLPTR);
     ScriptEditor(const ScriptEditor&) = default;
     ScriptEditor& operator=(const ScriptEditor&) = default;
     ~ScriptEditor() = default;
@@ -71,6 +71,8 @@ private:
 
     // Highlighter.
     QSyntaxHighlighter* syntaxHighlighter{ nullptr };
+
+    QString filename;
 
     void executeGoToLine();
 };

--- a/src/widgets/scripteditor.h
+++ b/src/widgets/scripteditor.h
@@ -43,8 +43,7 @@ protected:
     virtual void resizeEvent(QResizeEvent* ev) override;
     virtual void keyPressEvent(QKeyEvent* ev) override;
 
-public slots:
-    //void on_scriptIndexChanged(int index);
+    virtual void wheelEvent(QWheelEvent* ev) override;
 
 private slots:
     void on_blockCountChanged(int);

--- a/src/widgets/scripteditor.h
+++ b/src/widgets/scripteditor.h
@@ -1,3 +1,29 @@
+/*
+** scripteditor.h
+**
+** Copyright © Beyond Skyrim Development Team, 2017.
+** This file is part of OPENCK (https://github.com/Beyond-Skyrim/openck)
+**
+** OpenCK is free software; this file may be used under the terms of the GNU
+** General Public License version 3.0 or later as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.
+**
+** OpenCK is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Please review the following information to ensure the GNU General Public
+** License version 3.0 requirements will be met:
+** http://www.gnu.org/copyleft/gpl.html.
+**
+** You should have received a copy of the GNU General Public License version
+** 3.0 along with OpenCK; if not, write to the Free Software Foundation,
+** Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+**
+** Created Date: 18-Jul-2017
+*/
+
 #ifndef SCRIPTEDITOR_H
 #define SCRIPTEDITOR_H
 
@@ -14,7 +40,8 @@ public:
     ~ScriptEditor() = default;
 
 protected:
-    void resizeEvent(QResizeEvent* ev);
+    virtual void resizeEvent(QResizeEvent* ev) override;
+    virtual void keyPressEvent(QKeyEvent* ev) override;
 
 public slots:
     void on_scriptIndexChanged(int index);
@@ -45,6 +72,8 @@ private:
 
     // Highlighter.
     QSyntaxHighlighter* syntaxHighlighter{ nullptr };
+
+    void executeGoToLine();
 };
 
 #endif

--- a/src/widgets/scripteditor.h
+++ b/src/widgets/scripteditor.h
@@ -44,7 +44,7 @@ protected:
     virtual void keyPressEvent(QKeyEvent* ev) override;
 
 public slots:
-    void on_scriptIndexChanged(int index);
+    //void on_scriptIndexChanged(int index);
 
 private slots:
     void on_blockCountChanged(int);


### PR DESCRIPTION
Added support for opening multiple scripts at once in the script editor. Cleaned up some of the model code.

Some of the regex I changed to support matching better but this is likely to be all replaced with inclusion of the parser... however it's looking like properties are going to force a custom highlighting solution as QSyntaxHighlighter for whatever reason is very resistant to extensions to document wide block updates.